### PR TITLE
Refactor branch protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TF_PROJECTS = "."
 # -------------------------------------------------------------------------------------------------
 # Terraform configuration
 # -------------------------------------------------------------------------------------------------
-TF_VERSION = 0.13.7
+TF_VERSION = 0.14.11
 
 
 # -------------------------------------------------------------------------------------------------
@@ -77,7 +77,7 @@ test:
 			echo "OK"; \
 		else \
 			echo "Failed"; \
-			docker run $$(tty -s && echo "-it" || echo) --rm-v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:$(TF_VERSION) -rf .terraform/ || true; \
+			docker run $$(tty -s && echo "-it" || echo) --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" --entrypoint=rm hashicorp/terraform:$(TF_VERSION) -rf .terraform/ || true; \
 			exit 1; \
 		fi; \
 		echo; \

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ module "example_repo" {
 
 | Name | Type |
 |------|------|
-| [github_branch_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
+| [github_branch_protection.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_issue_label.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_collaborator.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborator) | resource |
@@ -170,6 +170,7 @@ module "example_repo" {
 | <a name="input_auto_init"></a> [auto\_init](#input\_auto\_init) | Meaningful only during create; set  to `true` to produce an initial commit in the repository. | `bool` | `true` | no |
 | <a name="input_collaborators"></a> [collaborators](#input\_collaborators) | Map of users with permissions. | `map(string)` | `{}` | no |
 | <a name="input_default_branch_protection"></a> [default\_branch\_protection](#input\_default\_branch\_protection) | Default branch protection settings. | <pre>object({<br>    enforce_admins                  = optional(bool)<br>    allows_deletions                = optional(bool)<br>    allows_force_pushes             = optional(bool)<br>    require_signed_commits          = optional(bool)<br>    required_linear_history         = optional(bool)<br>    require_conversation_resolution = optional(bool)<br>    push_restrictions               = optional(list(string))<br>    required_status_checks = optional(object({<br>      strict   = optional(bool)<br>      contexts = optional(list(string))<br>    }))<br>    required_pull_request_reviews = optional(object({<br>      dismiss_stale_reviews           = optional(bool)<br>      restrict_dismissals             = optional(bool)<br>      dismissal_restrictions          = optional(list(string))<br>      require_code_owner_reviews      = optional(bool)<br>      required_approving_review_count = optional(number)<br>    }))<br>  })</pre> | `{}` | no |
+| <a name="input_default_branch_protection_enabled"></a> [default\_branch\_protection\_enabled](#input\_default\_branch\_protection\_enabled) | Set to `false` if you want to disable branch protection for default branch | `bool` | `true` | no |
 | <a name="input_delete_branch_on_merge"></a> [delete\_branch\_on\_merge](#input\_delete\_branch\_on\_merge) | Automatically delete head branch after a pull request is merged. | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `name`, `namespace`, `tenant`, etc. | `string` | `"-"` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the repository. | `string` | `""` | no |
@@ -184,7 +185,7 @@ module "example_repo" {
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, e.g. `terraform`, `product`, `mobile` etc. | `string` | `null` | no |
 | <a name="input_pages"></a> [pages](#input\_pages) | The repository's GitHub Pages configuration. | <pre>object({<br>    source = object({<br>      branch = string<br>      path   = string<br>    })<br>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
-| <a name="input_teams"></a> [teams](#input\_teams) | Map of organization teams with permissions. | `map(string)` | `{}` | no |
+| <a name="input_teams"></a> [teams](#input\_teams) | Map of organization team names with permissions. | `map(string)` | `{}` | no |
 | <a name="input_template"></a> [template](#input\_template) | Use a template repository to create this repository. | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | A customer identifier, indicating who this instance of a resource is for. Could be used for application grouping. | `string` | `null` | no |
 | <a name="input_topics"></a> [topics](#input\_topics) | A list of topics to add to the repository. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 This Terraform module manages GitHub repositories. 
 Initially it was a backport from https://github.com/innovationnorway/terraform-github-repository which was written for 0.12 and as dynamic blocks were removed to be complied with 0.11 - this module will only allow branch protection for one branch, the default branch ( defaults to master ).
 
+## Important notice
+
+:warning: This module uses experimental optional attributes.
+
+More about it [here](https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes).
+
 ## Example Usage
 
 ### Create private repository
@@ -123,7 +129,7 @@ module "example_repo" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | >= 4.19.2 |
 
 ## Providers
@@ -142,7 +148,7 @@ module "example_repo" {
 
 | Name | Type |
 |------|------|
-| [github_branch_protection.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
+| [github_branch_protection.default](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_issue_label.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/issue_label) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_collaborator.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborator) | resource |
@@ -163,14 +169,7 @@ module "example_repo" {
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `policy` or `role`) | `list(string)` | `[]` | no |
 | <a name="input_auto_init"></a> [auto\_init](#input\_auto\_init) | Meaningful only during create; set  to `true` to produce an initial commit in the repository. | `bool` | `true` | no |
 | <a name="input_collaborators"></a> [collaborators](#input\_collaborators) | Map of users with permissions. | `map(string)` | `{}` | no |
-| <a name="input_default_branch"></a> [default\_branch](#input\_default\_branch) | The name of the default branch of the repository. | `string` | `"master"` | no |
-| <a name="input_default_branch_protection_dismiss_stale_reviews"></a> [default\_branch\_protection\_dismiss\_stale\_reviews](#input\_default\_branch\_protection\_dismiss\_stale\_reviews) | Dismiss approved reviews automatically when a new commit is pushed. Defaults to false. | `bool` | `true` | no |
-| <a name="input_default_branch_protection_enabled"></a> [default\_branch\_protection\_enabled](#input\_default\_branch\_protection\_enabled) | Do we want to enable branch protection for the default branch | `bool` | `false` | no |
-| <a name="input_default_branch_protection_enforce_admins"></a> [default\_branch\_protection\_enforce\_admins](#input\_default\_branch\_protection\_enforce\_admins) | Boolean, setting this to true enforces status checks for repository administrators. | `bool` | `false` | no |
-| <a name="input_default_branch_protection_require_code_owner_reviews"></a> [default\_branch\_protection\_require\_code\_owner\_reviews](#input\_default\_branch\_protection\_require\_code\_owner\_reviews) | Require an approved review in pull requests including files with a designated code owner. Defaults to false. | `bool` | `false` | no |
-| <a name="input_default_branch_protection_required_status_checks_contexts"></a> [default\_branch\_protection\_required\_status\_checks\_contexts](#input\_default\_branch\_protection\_required\_status\_checks\_contexts) | List of status checks, e.g. travis | `list(string)` | `[]` | no |
-| <a name="input_default_branch_protection_required_status_checks_strict"></a> [default\_branch\_protection\_required\_status\_checks\_strict](#input\_default\_branch\_protection\_required\_status\_checks\_strict) | Require branches to be up to date before merging. Defaults to false. | `bool` | `true` | no |
-| <a name="input_default_branch_protection_restrictions_teams"></a> [default\_branch\_protection\_restrictions\_teams](#input\_default\_branch\_protection\_restrictions\_teams) | The list of team slugs with push access. Always use slug of the team, not its name. Each team already has to have access to the repository. | `list(string)` | `[]` | no |
+| <a name="input_default_branch_protection"></a> [default\_branch\_protection](#input\_default\_branch\_protection) | Default branch protection settings. | <pre>object({<br>    enforce_admins                  = optional(bool)<br>    allows_deletions                = optional(bool)<br>    allows_force_pushes             = optional(bool)<br>    require_signed_commits          = optional(bool)<br>    required_linear_history         = optional(bool)<br>    require_conversation_resolution = optional(bool)<br>    push_restrictions               = optional(list(string))<br>    required_status_checks = optional(object({<br>      strict   = optional(bool)<br>      contexts = optional(list(string))<br>    }))<br>    required_pull_request_reviews = optional(object({<br>      dismiss_stale_reviews           = optional(bool)<br>      restrict_dismissals             = optional(bool)<br>      dismissal_restrictions          = optional(list(string))<br>      require_code_owner_reviews      = optional(bool)<br>      required_approving_review_count = optional(number)<br>    }))<br>  })</pre> | `{}` | no |
 | <a name="input_delete_branch_on_merge"></a> [delete\_branch\_on\_merge](#input\_delete\_branch\_on\_merge) | Automatically delete head branch after a pull request is merged. | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `name`, `namespace`, `tenant`, etc. | `string` | `"-"` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the repository. | `string` | `""` | no |
@@ -198,6 +197,7 @@ module "example_repo" {
 | Name | Description |
 |------|-------------|
 | <a name="output_repository"></a> [repository](#output\_repository) | Created repository |
+| <a name="output_repository_branch_protection"></a> [repository\_branch\_protection](#output\_repository\_branch\_protection) | Default branch protection settings |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/empty_repo/main.tf
+++ b/examples/empty_repo/main.tf
@@ -31,6 +31,8 @@ module "example" {
   allow_rebase_merge = true
 
   vulnerability_alerts = true
+
+  default_branch_protection_enabled = false
 }
 
 output "repository" {

--- a/examples/init_repo_with_permissions/main.tf
+++ b/examples/init_repo_with_permissions/main.tf
@@ -68,10 +68,26 @@ module "example" {
 
   vulnerability_alerts = true
 
-  default_branch_protection_enforce_admins                  = true
-  default_branch_protection_enabled                         = true
-  default_branch_protection_required_status_checks_contexts = ["Travis CI - Branch", "Travis CI - Pull Request"]
-  default_branch_protection_require_code_owner_reviews      = true
+  default_branch_protection = {
+    enforce_admins = true
+    allows_deletions = false
+    allows_force_pushes = false
+    require_signed_commits = true
+    required_linear_history = false
+    require_conversation_resolution = false
+    push_restrictions = []
+    required_status_checks = {
+      strict = true
+      contexts = ["Travis CI - Branch", "Travis CI - Pull Request"]
+    }
+    required_pull_request_reviews = {
+      dismiss_stale_reviews = true
+      restrict_dismissals   = false
+      dismissal_restrictions = []
+      require_code_owner_reviews = true
+      required_approving_review_count = 1
+    }
+  }
 
   depends_on = [
     github_team.maintainers,

--- a/examples/init_repo_with_permissions/main.tf
+++ b/examples/init_repo_with_permissions/main.tf
@@ -68,24 +68,14 @@ module "example" {
 
   vulnerability_alerts = true
 
+  # Overwrite some settings for default branch
   default_branch_protection = {
-    enforce_admins = true
-    allows_deletions = false
-    allows_force_pushes = false
-    require_signed_commits = true
-    required_linear_history = false
-    require_conversation_resolution = false
-    push_restrictions = []
+    require_signed_commits = false
     required_status_checks = {
-      strict = true
       contexts = ["Travis CI - Branch", "Travis CI - Pull Request"]
     }
     required_pull_request_reviews = {
-      dismiss_stale_reviews = true
-      restrict_dismissals   = false
-      dismissal_restrictions = []
-      require_code_owner_reviews = true
-      required_approving_review_count = 1
+      require_code_owner_reviews = false
     }
   }
 
@@ -97,4 +87,8 @@ module "example" {
 
 output "repository" {
   value = module.example.repository
+}
+
+output "repository_branch_protection" {
+  value = module.example.repository_branch_protection
 }

--- a/examples/init_repo_with_permissions/versions.tf
+++ b/examples/init_repo_with_permissions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     github = {
       source  = "integrations/github"

--- a/locals.tf
+++ b/locals.tf
@@ -10,4 +10,54 @@ locals {
       description = label["description"]
     }
   }
+
+  # These settings are default for branch protection
+  default_branch_protection = {
+    enforce_admins                  = true
+    allows_deletions                = false
+    allows_force_pushes             = false
+    require_signed_commits          = true
+    required_linear_history         = false
+    require_conversation_resolution = false
+    push_restrictions               = []
+    required_status_checks = {
+      strict   = true
+      contexts = []
+    }
+    required_pull_request_reviews = {
+      dismiss_stale_reviews           = true
+      restrict_dismissals             = false
+      dismissal_restrictions          = []
+      require_code_owner_reviews      = true
+      required_approving_review_count = 1
+    }
+  }
+
+  # Combine defaults with input parameters
+  # TODO: refactor if `deepmerge` is implemented https://github.com/hashicorp/terraform/issues/24987
+  # When you use `optional()` parameters all keys are defined and values are set to `null`.
+  # In this case `lookup` all the time return `null` when you reference the key.
+  # You have to use `if .. else` condition to sort it out.
+  required_status_checks        = var.default_branch_protection["required_status_checks"] != null ? var.default_branch_protection["required_status_checks"] : local.default_branch_protection["required_status_checks"]
+  required_pull_request_reviews = var.default_branch_protection["required_pull_request_reviews"] != null ? var.default_branch_protection["required_pull_request_reviews"] : local.default_branch_protection["required_pull_request_reviews"]
+  rendered_default_branch_protection = {
+    enforce_admins                  = var.default_branch_protection["enforce_admins"] != null ? var.default_branch_protection["enforce_admins"] : local.default_branch_protection["enforce_admins"]
+    allows_deletions                = var.default_branch_protection["allows_deletions"] != null ? var.default_branch_protection["allows_deletions"] : local.default_branch_protection["allows_deletions"]
+    allows_force_pushes             = var.default_branch_protection["allows_force_pushes"] != null ? var.default_branch_protection["allows_force_pushes"] : local.default_branch_protection["allows_force_pushes"]
+    require_signed_commits          = var.default_branch_protection["require_signed_commits"] != null ? var.default_branch_protection["require_signed_commits"] : local.default_branch_protection["require_signed_commits"]
+    required_linear_history         = var.default_branch_protection["required_linear_history"] != null ? var.default_branch_protection["required_linear_history"] : local.default_branch_protection["required_linear_history"]
+    require_conversation_resolution = var.default_branch_protection["require_conversation_resolution"] != null ? var.default_branch_protection["require_conversation_resolution"] : local.default_branch_protection["require_conversation_resolution"]
+    push_restrictions               = var.default_branch_protection["push_restrictions"] != null ? var.default_branch_protection["push_restrictions"] : local.default_branch_protection["push_restrictions"]
+    required_status_checks = {
+      strict   = local.required_status_checks["strict"] != null ? local.required_status_checks["strict"] : local.default_branch_protection["required_status_checks"]["strict"]
+      contexts = local.required_status_checks["contexts"] != null ? local.required_status_checks["contexts"] : local.default_branch_protection["required_status_checks"]["contexts"]
+    }
+    required_pull_request_reviews = {
+      dismiss_stale_reviews           = local.required_pull_request_reviews["dismiss_stale_reviews"] != null ? local.required_pull_request_reviews["dismiss_stale_reviews"] : local.default_branch_protection["required_pull_request_reviews"]["dismiss_stale_reviews"]
+      restrict_dismissals             = local.required_pull_request_reviews["restrict_dismissals"] != null ? local.required_pull_request_reviews["restrict_dismissals"] : local.default_branch_protection["required_pull_request_reviews"]["restrict_dismissals"]
+      dismissal_restrictions          = local.required_pull_request_reviews["dismissal_restrictions"] != null ? local.required_pull_request_reviews["dismissal_restrictions"] : local.default_branch_protection["required_pull_request_reviews"]["dismissal_restrictions"]
+      require_code_owner_reviews      = local.required_pull_request_reviews["require_code_owner_reviews"] != null ? local.required_pull_request_reviews["require_code_owner_reviews"] : local.default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
+      required_approving_review_count = local.required_pull_request_reviews["required_approving_review_count"] != null ? local.required_pull_request_reviews["required_approving_review_count"] : local.default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
+    }
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -38,26 +38,25 @@ locals {
   # When you use `optional()` parameters all keys are defined and values are set to `null`.
   # In this case `lookup` all the time return `null` when you reference the key.
   # You have to use `if .. else` condition to sort it out.
-  required_status_checks        = var.default_branch_protection["required_status_checks"] != null ? var.default_branch_protection["required_status_checks"] : local.default_branch_protection["required_status_checks"]
-  required_pull_request_reviews = var.default_branch_protection["required_pull_request_reviews"] != null ? var.default_branch_protection["required_pull_request_reviews"] : local.default_branch_protection["required_pull_request_reviews"]
+  clean_default_branch_protection = {
+    for k, v in var.default_branch_protection :
+    k => (v != null ? v : local.default_branch_protection[k])
+  }
   rendered_default_branch_protection = {
-    enforce_admins                  = var.default_branch_protection["enforce_admins"] != null ? var.default_branch_protection["enforce_admins"] : local.default_branch_protection["enforce_admins"]
-    allows_deletions                = var.default_branch_protection["allows_deletions"] != null ? var.default_branch_protection["allows_deletions"] : local.default_branch_protection["allows_deletions"]
-    allows_force_pushes             = var.default_branch_protection["allows_force_pushes"] != null ? var.default_branch_protection["allows_force_pushes"] : local.default_branch_protection["allows_force_pushes"]
-    require_signed_commits          = var.default_branch_protection["require_signed_commits"] != null ? var.default_branch_protection["require_signed_commits"] : local.default_branch_protection["require_signed_commits"]
-    required_linear_history         = var.default_branch_protection["required_linear_history"] != null ? var.default_branch_protection["required_linear_history"] : local.default_branch_protection["required_linear_history"]
-    require_conversation_resolution = var.default_branch_protection["require_conversation_resolution"] != null ? var.default_branch_protection["require_conversation_resolution"] : local.default_branch_protection["require_conversation_resolution"]
-    push_restrictions               = var.default_branch_protection["push_restrictions"] != null ? var.default_branch_protection["push_restrictions"] : local.default_branch_protection["push_restrictions"]
+    enforce_admins                  = local.clean_default_branch_protection["enforce_admins"]
+    allows_deletions                = local.clean_default_branch_protection["allows_deletions"]
+    allows_force_pushes             = local.clean_default_branch_protection["allows_force_pushes"]
+    require_signed_commits          = local.clean_default_branch_protection["require_signed_commits"]
+    required_linear_history         = local.clean_default_branch_protection["required_linear_history"]
+    require_conversation_resolution = local.clean_default_branch_protection["require_conversation_resolution"]
+    push_restrictions               = local.clean_default_branch_protection["push_restrictions"]
     required_status_checks = {
-      strict   = local.required_status_checks["strict"] != null ? local.required_status_checks["strict"] : local.default_branch_protection["required_status_checks"]["strict"]
-      contexts = local.required_status_checks["contexts"] != null ? local.required_status_checks["contexts"] : local.default_branch_protection["required_status_checks"]["contexts"]
+      for k, v in local.clean_default_branch_protection["required_status_checks"] :
+      k => (v != null ? v : local.default_branch_protection["required_status_checks"][k])
     }
     required_pull_request_reviews = {
-      dismiss_stale_reviews           = local.required_pull_request_reviews["dismiss_stale_reviews"] != null ? local.required_pull_request_reviews["dismiss_stale_reviews"] : local.default_branch_protection["required_pull_request_reviews"]["dismiss_stale_reviews"]
-      restrict_dismissals             = local.required_pull_request_reviews["restrict_dismissals"] != null ? local.required_pull_request_reviews["restrict_dismissals"] : local.default_branch_protection["required_pull_request_reviews"]["restrict_dismissals"]
-      dismissal_restrictions          = local.required_pull_request_reviews["dismissal_restrictions"] != null ? local.required_pull_request_reviews["dismissal_restrictions"] : local.default_branch_protection["required_pull_request_reviews"]["dismissal_restrictions"]
-      require_code_owner_reviews      = local.required_pull_request_reviews["require_code_owner_reviews"] != null ? local.required_pull_request_reviews["require_code_owner_reviews"] : local.default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
-      required_approving_review_count = local.required_pull_request_reviews["required_approving_review_count"] != null ? local.required_pull_request_reviews["required_approving_review_count"] : local.default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
+      for k, v in local.clean_default_branch_protection["required_pull_request_reviews"] :
+      k => (v != null ? v : local.default_branch_protection["required_pull_request_reviews"][k])
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -99,21 +99,29 @@ resource "github_issue_label" "main" {
   description = each.value["description"]
 }
 
-resource "github_branch_protection" "main" {
-  for_each = var.default_branch_protection_enabled ? toset(["default"]) : []
-
+resource "github_branch_protection" "default" {
   repository_id = github_repository.main.node_id
   pattern       = github_repository.main.default_branch
 
-  enforce_admins = var.default_branch_protection_enforce_admins
+  enforce_admins = var.default_branch_protection["enforce_admins"]
+  allows_deletions = var.default_branch_protection["allows_deletions"]
+  allows_force_pushes = var.default_branch_protection["allows_force_pushes"]
+  require_signed_commits = var.default_branch_protection["require_signed_commits"]
+  required_linear_history = var.default_branch_protection["required_linear_history"]
+  require_conversation_resolution = var.default_branch_protection["require_conversation_resolution"]
+  push_restrictions = var.default_branch_protection["push_restrictions"]
 
   required_status_checks {
-    strict   = var.default_branch_protection_required_status_checks_strict
-    contexts = var.default_branch_protection_required_status_checks_contexts
+    strict   = var.default_branch_protection["required_status_checks"]["strict"]
+    contexts = var.default_branch_protection["required_status_checks"]["contexts"]
   }
 
   required_pull_request_reviews {
-    require_code_owner_reviews = var.default_branch_protection_require_code_owner_reviews
-    dismiss_stale_reviews      = var.default_branch_protection_dismiss_stale_reviews
+    dismiss_stale_reviews = var.default_branch_protection["required_pull_request_reviews"]["dismiss_stale_reviews"]
+    restrict_dismissals   = var.default_branch_protection["required_pull_request_reviews"]["restrict_dismissals"]
+    dismissal_restrictions = var.default_branch_protection["required_pull_request_reviews"]["dismissal_restrictions"]
+    require_code_owner_reviews = var.default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
+    required_approving_review_count = var.default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
   }
+
 }

--- a/main.tf
+++ b/main.tf
@@ -103,25 +103,25 @@ resource "github_branch_protection" "default" {
   repository_id = github_repository.main.node_id
   pattern       = github_repository.main.default_branch
 
-  enforce_admins = var.default_branch_protection["enforce_admins"]
-  allows_deletions = var.default_branch_protection["allows_deletions"]
-  allows_force_pushes = var.default_branch_protection["allows_force_pushes"]
-  require_signed_commits = var.default_branch_protection["require_signed_commits"]
-  required_linear_history = var.default_branch_protection["required_linear_history"]
-  require_conversation_resolution = var.default_branch_protection["require_conversation_resolution"]
-  push_restrictions = var.default_branch_protection["push_restrictions"]
+  enforce_admins                  = local.rendered_default_branch_protection["enforce_admins"]
+  allows_deletions                = local.rendered_default_branch_protection["allows_deletions"]
+  allows_force_pushes             = local.rendered_default_branch_protection["allows_force_pushes"]
+  require_signed_commits          = local.rendered_default_branch_protection["require_signed_commits"]
+  required_linear_history         = local.rendered_default_branch_protection["required_linear_history"]
+  require_conversation_resolution = local.rendered_default_branch_protection["require_conversation_resolution"]
+  push_restrictions               = local.rendered_default_branch_protection["push_restrictions"]
 
   required_status_checks {
-    strict   = var.default_branch_protection["required_status_checks"]["strict"]
-    contexts = var.default_branch_protection["required_status_checks"]["contexts"]
+    strict   = local.rendered_default_branch_protection["required_status_checks"]["strict"]
+    contexts = local.rendered_default_branch_protection["required_status_checks"]["contexts"]
   }
 
   required_pull_request_reviews {
-    dismiss_stale_reviews = var.default_branch_protection["required_pull_request_reviews"]["dismiss_stale_reviews"]
-    restrict_dismissals   = var.default_branch_protection["required_pull_request_reviews"]["restrict_dismissals"]
-    dismissal_restrictions = var.default_branch_protection["required_pull_request_reviews"]["dismissal_restrictions"]
-    require_code_owner_reviews = var.default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
-    required_approving_review_count = var.default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
+    dismiss_stale_reviews           = local.rendered_default_branch_protection["required_pull_request_reviews"]["dismiss_stale_reviews"]
+    restrict_dismissals             = local.rendered_default_branch_protection["required_pull_request_reviews"]["restrict_dismissals"]
+    dismissal_restrictions          = local.rendered_default_branch_protection["required_pull_request_reviews"]["dismissal_restrictions"]
+    require_code_owner_reviews      = local.rendered_default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
+    required_approving_review_count = local.rendered_default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,9 @@ resource "github_issue_label" "main" {
   description = each.value["description"]
 }
 
-resource "github_branch_protection" "default" {
+resource "github_branch_protection" "main" {
+  for_each = var.default_branch_protection_enabled ? toset(["default"]) : []
+
   repository_id = github_repository.main.node_id
   pattern       = github_repository.main.default_branch
 
@@ -124,4 +126,5 @@ resource "github_branch_protection" "default" {
     required_approving_review_count = local.rendered_default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
   }
 
+  depends_on = [github_repository.main]
 }

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,4 @@ resource "github_branch_protection" "main" {
     require_code_owner_reviews      = local.rendered_default_branch_protection["required_pull_request_reviews"]["require_code_owner_reviews"]
     required_approving_review_count = local.rendered_default_branch_protection["required_pull_request_reviews"]["required_approving_review_count"]
   }
-
-  depends_on = [github_repository.main]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,6 @@ output "repository" {
 }
 
 output "repository_branch_protection" {
-  value       = github_branch_protection.default
+  value       = github_branch_protection.main
   description = "Default branch protection settings"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,9 @@
 output "repository" {
-  value = github_repository.main
-
+  value       = github_repository.main
   description = "Created repository"
+}
+
+output "repository_branch_protection" {
+  value       = github_branch_protection.default
+  description = "Default branch protection settings"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,7 @@ variable "archive_on_destroy" {
 variable "teams" {
   type        = map(string)
   default     = {}
-  description = "Map of organization teams with permissions."
+  description = "Map of organization team names with permissions."
 
   validation {
     condition = length(var.teams) > 0 ? alltrue([
@@ -178,6 +178,12 @@ variable "pages" {
   })
   default     = null
   description = "The repository's GitHub Pages configuration."
+}
+
+variable "default_branch_protection_enabled" {
+  type        = bool
+  default     = true
+  description = "Set to `false` if you want to disable branch protection for default branch"
 }
 
 variable "default_branch_protection" {

--- a/variables.tf
+++ b/variables.tf
@@ -129,12 +129,6 @@ variable "gitignore_template" {
   description = "Meaningful only during create, will be ignored after repository creation. Use the name of the template without the extension. For example, \"Terraform\"."
 }
 
-variable "default_branch" {
-  type        = string
-  default     = "master"
-  description = "The name of the default branch of the repository."
-}
-
 variable "archived" {
   type        = bool
   default     = false
@@ -188,45 +182,26 @@ variable "pages" {
 
 variable "default_branch_protection" {
   type = object({
-    enforce_admins = bool
-    allows_deletions = bool
-    allows_force_pushes = bool
-    require_signed_commits = bool
-    required_linear_history = bool
-    require_conversation_resolution = bool
-    push_restrictions = list(string)
-    required_status_checks = object({
-      strict = bool
-      contexts = list(string)
-    })
-    required_pull_request_reviews = object({
-      dismiss_stale_reviews = bool
-      restrict_dismissals   = bool
-      dismissal_restrictions = list(string)
-      require_code_owner_reviews = bool
-      required_approving_review_count = number
-    })
+    enforce_admins                  = optional(bool)
+    allows_deletions                = optional(bool)
+    allows_force_pushes             = optional(bool)
+    require_signed_commits          = optional(bool)
+    required_linear_history         = optional(bool)
+    require_conversation_resolution = optional(bool)
+    push_restrictions               = optional(list(string))
+    required_status_checks = optional(object({
+      strict   = optional(bool)
+      contexts = optional(list(string))
+    }))
+    required_pull_request_reviews = optional(object({
+      dismiss_stale_reviews           = optional(bool)
+      restrict_dismissals             = optional(bool)
+      dismissal_restrictions          = optional(list(string))
+      require_code_owner_reviews      = optional(bool)
+      required_approving_review_count = optional(number)
+    }))
   })
-  default = {
-    enforce_admins = true
-    allows_deletions = false
-    allows_force_pushes = false
-    require_signed_commits = true
-    required_linear_history = false
-    require_conversation_resolution = false
-    push_restrictions = []
-    required_status_checks = {
-      strict = true
-      contexts = []
-    }
-    required_pull_request_reviews = {
-      dismiss_stale_reviews = true
-      restrict_dismissals   = false
-      dismissal_restrictions = []
-      require_code_owner_reviews = true
-      required_approving_review_count = 1
-    }
-  }
+  default     = {} # See defaults in locals.tf
   description = "Default branch protection settings."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -186,46 +186,48 @@ variable "pages" {
   description = "The repository's GitHub Pages configuration."
 }
 
-variable "default_branch_protection_enabled" {
-  type        = bool
-  default     = false
-  description = "Do we want to enable branch protection for the default branch"
-}
-
-variable "default_branch_protection_enforce_admins" {
-  type        = bool
-  default     = false
-  description = "Boolean, setting this to true enforces status checks for repository administrators."
-}
-
-variable "default_branch_protection_required_status_checks_strict" {
-  type        = bool
-  default     = true
-  description = "Require branches to be up to date before merging. Defaults to false."
-}
-
-variable "default_branch_protection_required_status_checks_contexts" {
-  type        = list(string)
-  default     = []
-  description = "List of status checks, e.g. travis"
-}
-
-variable "default_branch_protection_dismiss_stale_reviews" {
-  type        = bool
-  default     = true
-  description = "Dismiss approved reviews automatically when a new commit is pushed. Defaults to false."
-}
-
-variable "default_branch_protection_require_code_owner_reviews" {
-  type        = bool
-  default     = false
-  description = "Require an approved review in pull requests including files with a designated code owner. Defaults to false."
-}
-
-variable "default_branch_protection_restrictions_teams" {
-  type        = list(string)
-  default     = []
-  description = "The list of team slugs with push access. Always use slug of the team, not its name. Each team already has to have access to the repository."
+variable "default_branch_protection" {
+  type = object({
+    enforce_admins = bool
+    allows_deletions = bool
+    allows_force_pushes = bool
+    require_signed_commits = bool
+    required_linear_history = bool
+    require_conversation_resolution = bool
+    push_restrictions = list(string)
+    required_status_checks = object({
+      strict = bool
+      contexts = list(string)
+    })
+    required_pull_request_reviews = object({
+      dismiss_stale_reviews = bool
+      restrict_dismissals   = bool
+      dismissal_restrictions = list(string)
+      require_code_owner_reviews = bool
+      required_approving_review_count = number
+    })
+  })
+  default = {
+    enforce_admins = true
+    allows_deletions = false
+    allows_force_pushes = false
+    require_signed_commits = true
+    required_linear_history = false
+    require_conversation_resolution = false
+    push_restrictions = []
+    required_status_checks = {
+      strict = true
+      contexts = []
+    }
+    required_pull_request_reviews = {
+      dismiss_stale_reviews = true
+      restrict_dismissals   = false
+      dismissal_restrictions = []
+      require_code_owner_reviews = true
+      required_approving_review_count = 1
+    }
+  }
+  description = "Default branch protection settings."
 }
 
 variable "issue_labels" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.13"
   required_providers {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 0.13"
+  experiments      = [module_variable_optional_attrs]
+  required_version = ">= 0.14"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
- ⚠️ Reduce number of parameters required for default branch protection (Breaking change)
- Bump requirements for the module to `v0.14`

Note: there is a known issue with outputs - you have to apply it twice

```
Changes to Outputs:
  ~ repository_branch_protection = {
      ~ default = {
          ~ push_restrictions               = null -> []
          ~ required_pull_request_reviews   = [
              ~ {
                  ~ dismissal_restrictions          = null -> []
                    # (4 unchanged elements hidden)
                },
            ]
            # (10 unchanged elements hidden)
        }
    }
```