### PR TITLE
Fix error with sensitive values in environment secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ module "example_repo" {
 | Name | Description |
 |------|-------------|
 | <a name="output_dependabot_secrets"></a> [dependabot\_secrets](#output\_dependabot\_secrets) | A map of dependabot secret names |
+| <a name="output_environments"></a> [environments](#output\_environments) | A list of created environments |
+| <a name="output_environments_secrets"></a> [environments\_secrets](#output\_environments\_secrets) | A map of environment secret names |
 | <a name="output_repository"></a> [repository](#output\_repository) | Created repository |
 | <a name="output_repository_branch_protection"></a> [repository\_branch\_protection](#output\_repository\_branch\_protection) | Default branch protection settings |
 | <a name="output_repository_secrets"></a> [repository\_secrets](#output\_repository\_secrets) | A map of create secret names |

--- a/examples/init_repo_with_environmets/main.tf
+++ b/examples/init_repo_with_environmets/main.tf
@@ -68,3 +68,11 @@ module "example" {
 output "repository" {
   value = module.example.repository
 }
+
+output "environments" {
+  value = module.example.environments
+}
+
+output "environments_secrets" {
+  value = module.example.environments_secrets
+}

--- a/examples/init_repo_with_environmets/main.tf
+++ b/examples/init_repo_with_environmets/main.tf
@@ -41,11 +41,22 @@ module "example" {
         users = [data.github_user.this.id]
       }
       secrets = {
+        TEST_SECRET = {},
         PLAIN_TEXT_SECRET = {
-          plaintext_value = "some_secret"
+          plaintext_value = sensitive("some_secret")
         }
       }
     },
+    test = {
+      secrets = {
+        ENCRYPTED_SECRET = {
+          # Value encrypted with organization public key
+          # Public key: https://docs.github.com/en/rest/reference/actions#get-an-organization-public-key
+          # Ecnryption: https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
+          encrypted_value = "P1wD+Byzy0JvL77qILs1gLj1wpDIDYIKGcHJbuILlTq3lNLgxDQuHXLVYknj2nx6uaeNGx3AmgsO+Nak"
+        }
+      }
+    }
     prod = {
       branch_policy = {
         protected_branches = true

--- a/locals.tf
+++ b/locals.tf
@@ -38,13 +38,9 @@ locals {
     }
   }
 
-  environments_secrets = { for name, env in var.environments :
-    replace(lower(name), " ", "-") => env["secrets"] if env["secrets"] != null
-  }
-
-  rendered_environments_secrets = merge([for ename, secrets in local.environments_secrets :
-    { for sname, secret in secrets :
-      "${ename}:${sname}" => merge(secret, {
+  rendered_environments_secrets = merge([for ename, env in var.environments :
+    { for sname, secret in(env["secrets"] != null ? env["secrets"] : {}) :
+      "${replace(lower(ename), " ", "-")}:${sname}" => merge(secret, {
         environment = ename
         secret_name = sname
       })

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,21 @@ output "dependabot_secrets" {
   }
 }
 
+output "environments" {
+  description = "A list of created environments"
+  value       = github_repository_environment.this
+}
+
+output "environments_secrets" {
+  description = "A map of environment secret names"
+  value = {
+    for name, secret in github_actions_environment_secret.this : name => {
+      created = secret.created_at
+      updated = secret.updated_at
+    }
+  }
+}
+
 output "repository_webhook_urls" {
   description = "Webhook URLs"
   value       = { for k, v in github_repository_webhook.this : k => v.url }


### PR DESCRIPTION
This will fix error if a sensitive value is passed to secrets:

```
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/repositories/main.tf line 197, in resource "github_actions_environment_secret" "this":
│  197:   for_each = local.rendered_environments_secrets
│     ├────────────────
│     │ local.rendered_environments_secrets has a sensitive value
│ 
│ Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource
│ instance key.
```