### PR TITLE
fix: Remove branch protection if repository is archived

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,14 +53,14 @@ locals {
     secret_scanning_push_protection = "disabled"
   }
 
-  rendered_branch_protection = merge(
+  rendered_branch_protection = var.archived != true ? merge(
     # Branch protection rules for default branch
     var.default_branch_protection_enabled ? {
       default = var.default_branch_protection
     } : {},
     # Additional branch protection rules
     var.branch_protection
-  )
+  ) : {}
 
   # Combine defaults with input parameters
   rendered_webhooks = {


### PR DESCRIPTION
After recent changes in GitHub branch protection page is not more available for archived repositories.