### PR TITLE
Revert "fix: Remove branch protection if repository is archived"

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,14 +53,14 @@ locals {
     secret_scanning_push_protection = "disabled"
   }
 
-  rendered_branch_protection = var.archived != true ? merge(
+  rendered_branch_protection = merge(
     # Branch protection rules for default branch
     var.default_branch_protection_enabled ? {
       default = var.default_branch_protection
     } : {},
     # Additional branch protection rules
     var.branch_protection
-  ) : {}
+  )
 
   # Combine defaults with input parameters
   rendered_webhooks = {


### PR DESCRIPTION
Reverts Flaconi/terraform-github-repository#51

Something has been changed in GitHub API and now this fix causing resources to be deleted, but branch protection could not be deleted for archived repos.