### PR TITLE
fix: Pin github provider version to `5.x`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ TF_PROJECTS = "."
 # -------------------------------------------------------------------------------------------------
 # Terraform configuration
 # -------------------------------------------------------------------------------------------------
-TF_VERSION = 1.3.9
+TF_VERSION = 1.5.7
 
 
 # -------------------------------------------------------------------------------------------------
 # Terraform-docs configuration
 # -------------------------------------------------------------------------------------------------
-TFDOCS_VERSION = 0.16.0-0.31
+TFDOCS_VERSION = 0.16.0-0.34
 
 # Adjust your delimiter here or overwrite via make arguments
 TFDOCS_DELIM_START = <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ module "example_repo" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | >= 5.16.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 5.16 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | >= 5.16.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 5.16 |
 
 ## Modules
 

--- a/examples/empty_repo/versions.tf
+++ b/examples/empty_repo/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_from_template/versions.tf
+++ b/examples/init_repo_from_template/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_branch_protection/versions.tf
+++ b/examples/init_repo_with_branch_protection/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_deploy_keys/versions.tf
+++ b/examples/init_repo_with_deploy_keys/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_environmets/versions.tf
+++ b/examples/init_repo_with_environmets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_permissions/versions.tf
+++ b/examples/init_repo_with_permissions/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_secrets/versions.tf
+++ b/examples/init_repo_with_secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/examples/init_repo_with_webhooks/versions.tf
+++ b/examples/init_repo_with_webhooks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.16.0"
+      version = "~> 5.16"
     }
   }
 }


### PR DESCRIPTION
`push_restrictions` was replaced with `push_allowances` in github provider `6.0+`.

Ref: https://github.com/integrations/terraform-provider-github/pull/2045